### PR TITLE
only run CI for firmware/ changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,10 @@ name: Build Fimware
 on:
   push:
     branches: [ main ]
+    paths: 'firmware/**'
   pull_request:
     branches: [ main ]
+    paths: 'firmware/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This PR should change the Github CI Action to only run for changes in `firmware/`

* [ ] Needs testing

resolves #49 