### PR TITLE
Create Github release when pushing a specific tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       # Install python 3.x
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9.0'
       # Set the short sha and save it to a global github variable
       - name: get shortsha
         id: vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             New release
           draft: false
           prerelease: false
-       - name: Upload Release Asset
+      - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,12 @@ jobs:
             New release
           draft: false
           prerelease: false
+       - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./${{ steps.vars.outputs.sha_short }}.bin
+          asset_name: ${{ steps.vars.outputs.sha_short }}.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9.0'
-      - name: get shortsha
+      - name: get shortsha and tag name
         id: vars
         run: |
          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
+         echo ::set-output name=release_tag::$(echo "$GITHUB_REF" | cut -d / -f 3)
       # Install PlatformIO
       - name: Install platformio
         run: |
@@ -40,7 +41,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body: |
-            New release
+            New release ${{ steps.vars.outputs.release_tag }}
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           platformio run -d "${GITHUB_WORKSPACE}/firmware"
           mv "${GITHUB_WORKSPACE}/firmware/.pio/build/esp32/firmware.bin" "${GITHUB_WORKSPACE}/${{ steps.vars.outputs.sha_short }}.bin"
           MD5SUM=$(md5sum "${GITHUB_WORKSPACE}/${{ steps.vars.outputs.sha_short }}.bin" | awk '{print $1}')
-          echo "${{ steps.vars.outputs.release_tag }};ARCHIVE/${{ steps.vars.outputs.sha_short }}.bin;${MD5SUM}" > "${GITHUB_WORKSPACE}/LATEST"
+          echo "${{ steps.vars.outputs.release_tag }};${{ steps.vars.outputs.sha_short }}.bin;${MD5SUM}" > "${GITHUB_WORKSPACE}/LATEST.github"
 
       # Upload artifact for further processing
       - name: Upload firmware artifact
@@ -69,6 +69,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./LATEST
+          asset_path: ./LATEST.github
           asset_name: LATEST
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+Name: Create release
 on:
   push:
     # Sequence of patterns matched against refs/tags
@@ -15,10 +16,23 @@ jobs:
         id: vars
         run: |
          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
-      - name: Checkout artifact
-        uses: actions/download-artifact@v2
+      # Install PlatformIO
+      - name: Install platformio
+        uses: actions/checkout@v2
+        uses: actions/setup-python@v2
           with:
-            name: ${{ steps.vars.outputs.sha_short }}.bin
+            python-version: '3.9.0'
+        run: |
+          set -x
+          pip install platformio
+          platformio run -d "${GITHUB_WORKSPACE}/firmware"
+          mv "${GITHUB_WORKSPACE}/firmware/.pio/build/esp32/firmware.bin" "${GITHUB_WORKSPACE}/${{ steps.vars.outputs.sha_short }}.bin"
+      # Upload artifact for further processing
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.vars.outputs.sha_short }}.bin
+          path: ./${{ steps.vars.outputs.sha_short }}.bin
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
       # Install PlatformIO
       - name: Install platformio
-        uses: actions/checkout@v2
-        uses: actions/setup-python@v2
-          with:
-            python-version: '3.9.0'
+        uses: 
+          - actions/checkout@v2
+          - actions/setup-python@v2
+              with:
+                python-version: '3.9.0'
         run: |
           set -x
           pip install platformio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,25 @@
-Name: Create release
+name: Create release
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
-name: Create Release
-
 jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.0'
       - name: get shortsha
         id: vars
         run: |
          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
       # Install PlatformIO
       - name: Install platformio
-        uses: 
-          - actions/checkout@v2
-          - actions/setup-python@v2
-              with:
-                python-version: '3.9.0'
         run: |
           set -x
           pip install platformio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,25 @@ jobs:
         run: |
          echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
          echo ::set-output name=release_tag::$(echo "$GITHUB_REF" | cut -d / -f 3)
-      # Install PlatformIO
+      # Build firmware
       - name: Install platformio
         run: |
           set -x
           pip install platformio
           platformio run -d "${GITHUB_WORKSPACE}/firmware"
           mv "${GITHUB_WORKSPACE}/firmware/.pio/build/esp32/firmware.bin" "${GITHUB_WORKSPACE}/${{ steps.vars.outputs.sha_short }}.bin"
+          MD5SUM=$(md5sum "${GITHUB_WORKSPACE}/${{ steps.vars.outputs.sha_short }}.bin" | awk '{print $1}')
+          echo "${{ steps.vars.outputs.release_tag }};ARCHIVE/${{ steps.vars.outputs.sha_short }}.bin;${MD5SUM}" > "${GITHUB_WORKSPACE}/LATEST"
+
       # Upload artifact for further processing
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ steps.vars.outputs.sha_short }}.bin
-          path: ./${{ steps.vars.outputs.sha_short }}.bin
+          path: |
+            ./${{ steps.vars.outputs.sha_short }}.bin
+            ./LATEST
+      # Create release in Github
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -44,8 +50,9 @@ jobs:
             New release ${{ steps.vars.outputs.release_tag }}
           draft: false
           prerelease: false
+      # Upload Asset to Github Release
       - name: Upload Release Asset
-        id: upload-release-asset
+        id: upload-release-asset-firmware
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,4 +60,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./${{ steps.vars.outputs.sha_short }}.bin
           asset_name: ${{ steps.vars.outputs.sha_short }}.bin
+          asset_content_type: application/octet-stream
+      # Upload LATEST info as release asset
+      - name: Upload Release Asset, LATEST info
+        id: upload-release-asset-LATEST
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./LATEST
+          asset_name: LATEST
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,4 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./${{ steps.vars.outputs.sha_short }}.bin
           asset_name: ${{ steps.vars.outputs.sha_short }}.bin
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: get shortsha
+        id: vars
+        run: |
+         echo ::set-output name=sha_short::$(git rev-parse --short=8 ${{ github.sha }})
+      - name: Checkout artifact
+        uses: actions/download-artifact@v2
+          with:
+            name: ${{ steps.vars.outputs.sha_short }}.bin
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            New release
+          draft: false
+          prerelease: false


### PR DESCRIPTION
In order to automatically create releases a new github action was added. Whenever a tag is created which starts with "v" a build will be done and a release will be created. 
The version tag should follow semantic versioning rules (which is not enforced by now): vX.Y.Z

The release will get two files: The firmware and a LATEST file which has the version number, the firmware filename and the md5 checksum of the file. 
It can be accessed by https://github.com/MaibornWolff/clean-air/releases/latest/download/LATEST. Please note that you have to follow the redirect you get from Github.

